### PR TITLE
deploy to kubernetes ci when master/release

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,7 @@ buildMvn {
   mvnDeploy = 'yes'
   publishAPI = 'yes'
   runLintRamlCop = 'yes'
+  doKubeDeploy =  true
 
   doDocker = {
     buildJavaDocker {


### PR DESCRIPTION
turns on doKubeDeploy to deploy docker image to ci kubernetes environment when snapshot or release artifacts are built.