### PR TITLE
MODTEMPENG-44 update create password email template

### DIFF
--- a/src/main/resources/templates/db_scripts/populate-event-configs.sql
+++ b/src/main/resources/templates/db_scripts/populate-event-configs.sql
@@ -6,7 +6,7 @@ INSERT INTO event_configurations (id, jsonb) VALUES
  "templates": [
    {
      "templateId": "263d4e33-db8d-4e07-9060-11f442320c05",
-     "outputFormat": "text/plain",
+     "outputFormat": "text/html",
      "deliveryChannel": "email"
    }
  ]


### PR DESCRIPTION
## Purpose
Update create password email template so that create password page link does not display but replaced with the link text - 'visit this link' which is hyperlinked to the create password page

Resolves: [MODTEMPENG-44](https://issues.folio.org/browse/MODTEMPENG-44)

## Approach 
Update populate-event-configs.sql script that saves templates to DB