### PR TITLE
MODEVENTC-19 update RMB and vertx versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,10 +14,10 @@
   </licenses>
 
   <properties>
-    <raml-module-builder.version>29.0.1</raml-module-builder.version>
+    <raml-module-builder.version>30.0.2</raml-module-builder.version>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vertx.version>3.8.1</vertx.version>
+    <vertx.version>3.9.1</vertx.version>
     <rest-assured.version>3.3.0</rest-assured.version>
   </properties>
 

--- a/src/main/java/org/folio/rest/impl/EventConfigAPIs.java
+++ b/src/main/java/org/folio/rest/impl/EventConfigAPIs.java
@@ -1,6 +1,10 @@
 package org.folio.rest.impl;
 
-import io.vertx.core.*;
+import java.util.Map;
+
+import javax.ws.rs.core.Response;
+
+import org.folio.cql2pgjson.CQL2PgJSON;
 import org.folio.rest.impl.util.EventConfigHelper;
 import org.folio.rest.jaxrs.model.EventConfigCollection;
 import org.folio.rest.jaxrs.model.EventConfigEntity;
@@ -12,10 +16,13 @@ import org.folio.rest.persist.PgUtil;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.persist.cql.CQLWrapper;
 import org.folio.rest.persist.interfaces.Results;
-import org.folio.cql2pgjson.CQL2PgJSON;
 
-import javax.ws.rs.core.Response;
-import java.util.Map;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
 
 public class EventConfigAPIs implements EventConfig {
 
@@ -38,7 +45,7 @@ public class EventConfigAPIs implements EventConfig {
       .map(GetEventConfigResponse::respond200WithApplicationJson)
       .map(Response.class::cast)
       .otherwise(EventConfigHelper::mapException)
-      .setHandler(asyncResultHandler);
+      .onComplete(asyncResultHandler);
   }
 
   private Future<CQLWrapper> buildSqlWrapper(String query, int offset, int limit) {


### PR DESCRIPTION
## Approach
- Update to RMB v30.0.2
- Update vertx to 3.9.1
- Do all related changes according to RMB upgrading notes

Resolves: [MODEVENTC-19](https://issues.folio.org/browse/MODEVENTC-19)