### PR TITLE
MODEVENTC-35 Upgrade to RMB 33.0.4 and Log4j 2.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   </licenses>
 
   <properties>
-    <raml-module-builder.version>33.0.0</raml-module-builder.version>
+    <raml-module-builder.version>33.0.4</raml-module-builder.version>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <vertx.version>4.1.0.CR1</vertx.version>


### PR DESCRIPTION
[MODEVENTC-35](https://issues.folio.org/browse/MODEVENTC-35)

Upgrade to RMB 33.0.4 which includes Log4j version with CVE-2021-44228 vulnerability fixed.