### PR TITLE
MODEVENTC-38 Update RMB to v33.2.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,10 +14,10 @@
   </licenses>
 
   <properties>
-    <raml-module-builder.version>33.0.4</raml-module-builder.version>
+    <raml-module-builder.version>33.2.4</raml-module-builder.version>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vertx.version>4.1.0.CR1</vertx.version>
+    <vertx.version>4.2.4</vertx.version>
     <rest-assured.version>4.3.0</rest-assured.version>
   </properties>
 
@@ -61,16 +61,6 @@
         <version>${vertx.version}</version>
         <type>pom</type>
         <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-sql-client</artifactId>
-        <version>${vertx.version}-FOLIO</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-pg-client</artifactId>
-        <version>${vertx.version}-FOLIO</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
### Purpose
In the scope of the task on module upgrade, proper actions were fulfilled following instructions to upgrade RAML
### Approach

- Updated RMB version
- Updated Vertx version
- Removed FOLIO fork of the vertx-sql-client and vertx-pg-client

### Learning
https://issues.folio.org/browse/MODEVENTC-38
https://github.com/folio-org/raml-module-builder/blob/master/doc/upgrading.md
