### PR TITLE
MODEVENTC-43 Upgrade to RMB v35.0.0, Vertx v4.3.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,10 +14,10 @@
   </licenses>
 
   <properties>
-    <raml-module-builder.version>34.0.0</raml-module-builder.version>
+    <raml-module-builder.version>35.0.0</raml-module-builder.version>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vertx.version>4.2.4</vertx.version>
+    <vertx.version>4.3.3</vertx.version>
     <rest-assured.version>4.3.0</rest-assured.version>
   </properties>
 


### PR DESCRIPTION
Resolves [MODEVENTC-43](https://issues.folio.org/browse/MODEVENTC-43)