### PR TITLE
MODEVENTC-69: upgrade module to vert.x 5.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 2026-XX-XX v2.10.0-SNAPSHOT 
+* Upgrade module to Vert.x 5.0 ([MODEVENTC-69](https://folio-org.atlassian.net/browse/MODEVENTC-69))
+
 ## 2025-03-13 v2.9.0
 * Java and RMB version upgrade Sunflower [FOLIO-4224](https://folio-org.atlassian.net/browse/FOLIO-4224) 
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
     <!-- Test dependency versions -->
     <rest-assured.version>6.0.0</rest-assured.version>
-    <aspectj.version>1.9.25.1</aspectj.version>
+    <aspectj.version>1.9.22.1</aspectj.version>
     <junit.version>4.13.2</junit.version>
 
     <!-- Plugin versions -->

--- a/pom.xml
+++ b/pom.xml
@@ -14,13 +14,29 @@
   </licenses>
 
   <properties>
-    <raml-module-builder.version>35.4.0</raml-module-builder.version>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vertx.version>4.5.13</vertx.version>
-    <rest-assured.version>5.5.1</rest-assured.version>
     <java.version>21</java.version>
-    <aspectj.version>1.9.22.1</aspectj.version>
+
+    <!-- Dependency versions -->
+    <raml-module-builder.version>36.0.0-SNAPSHOT</raml-module-builder.version>
+    <vertx.version>5.0.6</vertx.version>
+    <log4j.version>2.25.2</log4j.version>
+
+    <!-- Test dependency versions -->
+    <rest-assured.version>6.0.0</rest-assured.version>
+    <aspectj.version>1.9.25.1</aspectj.version>
+    <junit.version>4.13.2</junit.version>
+
+    <!-- Plugin versions -->
+    <maven-compiler-plugin.version>3.14.1</maven-compiler-plugin.version>
+    <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
+    <aspectj-maven-plugin.version>1.14.1</aspectj-maven-plugin.version>
+    <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
+    <copy-rename-maven-plugin.version>1.0.1</copy-rename-maven-plugin.version>
+    <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
+    <maven-shade-plugin.version>3.6.1</maven-shade-plugin.version>
+    <maven-release-plugin.version>3.1.1</maven-release-plugin.version>
   </properties>
 
   <dependencyManagement>
@@ -28,7 +44,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.24.3</version>
+        <version>${log4j.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -71,6 +87,12 @@
       <version>${raml-module-builder.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -91,7 +113,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.14.0</version>
+        <version>${maven-compiler-plugin.version}</version>
         <configuration>
           <release>${java.version}</release>
           <encoding>UTF-8</encoding>
@@ -119,7 +141,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
-        <version>3.6.0</version>
+        <version>${build-helper-maven-plugin.version}</version>
         <executions>
           <execution>
             <id>add_generated_sources_folder</id>
@@ -153,7 +175,7 @@
       <plugin>
         <groupId>dev.aspectj</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
-        <version>1.14</version>
+        <version>${aspectj-maven-plugin.version}</version>
         <configuration>
           <verbose>true</verbose>
           <release>${java.version}</release>
@@ -195,7 +217,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.3.1</version>
+        <version>${maven-resources-plugin.version}</version>
         <executions>
           <execution>
             <id>copy-resources</id>
@@ -236,7 +258,7 @@
       <plugin>
         <groupId>com.coderplus.maven.plugins</groupId>
         <artifactId>copy-rename-maven-plugin</artifactId>
-        <version>1.0.1</version>
+        <version>${copy-rename-maven-plugin.version}</version>
         <executions>
           <execution>
             <id>rename-descriptor-outputs</id>
@@ -263,7 +285,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-antrun-plugin</artifactId>
-        <version>3.1.0</version>
+        <version>${maven-antrun-plugin.version}</version>
         <executions>
           <execution>
             <!-- Replace the baseUri in the RAMLs that have been copied to
@@ -286,7 +308,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.6.0</version>
+        <version>${maven-shade-plugin.version}</version>
         <configuration>
           <filters>
             <filter>
@@ -312,6 +334,7 @@
                     <Multi-Release>true</Multi-Release>
                   </manifestEntries>
                 </transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
               </transformers>
               <artifactSet />
               <outputFile>${project.build.directory}/${project.artifactId}-fat.jar</outputFile>
@@ -323,7 +346,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
-        <version>3.1.1</version>
+        <version>${maven-release-plugin.version}</version>
         <configuration>
           <preparationGoals>clean verify</preparationGoals>
           <tagNameFormat>v@{project.version}</tagNameFormat>

--- a/src/main/java/org/folio/rest/impl/EventConfigAPIs.java
+++ b/src/main/java/org/folio/rest/impl/EventConfigAPIs.java
@@ -75,7 +75,7 @@ public class EventConfigAPIs implements EventConfig {
     String[] fieldList = {"*"};
     Promise<Results<EventEntity>> promise = Promise.promise();
     postgresClient.get(EVENT_CONFIGS, EventEntity.class, fieldList, cqlWrapper,
-      true, false, promise);
+      true, false, promise::handle);
     return promise.future();
   }
 

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -12,7 +12,7 @@ appenders = console
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{HH:mm:ss} [$${FolioLoggingContext:requestid}] [$${FolioLoggingContext:tenantid}] [$${FolioLoggingContext:userid}] [$${FolioLoggingContext:moduleid}] %-5p %-20.20C{1} %m%n
+appender.console.layout.pattern = %d{HH:mm:ss} [$${FolioLoggingContext:requestId}] [$${FolioLoggingContext:tenantId}] [$${FolioLoggingContext:userId}] [$${FolioLoggingContext:moduleId}] %-5p %-20.20C{1} %m%n
 
 rootLogger.level = info
 rootLogger.appenderRefs = info

--- a/src/main/resources/log4j2-json.properties
+++ b/src/main/resources/log4j2-json.properties
@@ -18,19 +18,19 @@ appender.console.layout.stacktraceAsString = true
 
 appender.console.layout.requestId.type = KeyValuePair
 appender.console.layout.requestId.key = requestId
-appender.console.layout.requestId.value = $${FolioLoggingContext:requestid}
+appender.console.layout.requestId.value = $${FolioLoggingContext:requestId}
 
 appender.console.layout.tenantId.type = KeyValuePair
 appender.console.layout.tenantId.key = tenantId
-appender.console.layout.tenantId.value = $${FolioLoggingContext:tenantid}
+appender.console.layout.tenantId.value = $${FolioLoggingContext:tenantId}
 
 appender.console.layout.userId.type = KeyValuePair
 appender.console.layout.userId.key = userId
-appender.console.layout.userId.value = $${FolioLoggingContext:userid}
+appender.console.layout.userId.value = $${FolioLoggingContext:userId}
 
 appender.console.layout.moduleId.type = KeyValuePair
 appender.console.layout.moduleId.key = moduleId
-appender.console.layout.moduleId.value = $${FolioLoggingContext:moduleid}
+appender.console.layout.moduleId.value = $${FolioLoggingContext:moduleId}
 
 rootLogger.level = info
 rootLogger.appenderRefs = info

--- a/src/test/java/org/folio/impl/EventConfigAPIsTest.java
+++ b/src/test/java/org/folio/impl/EventConfigAPIsTest.java
@@ -14,7 +14,6 @@ import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.ext.web.client.HttpResponse;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.HttpStatus;
@@ -42,6 +41,7 @@ import java.util.UUID;
 
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertTrue;
+import static org.apache.commons.lang3.RandomStringUtils.secure;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TOKEN;
 import static org.hamcrest.CoreMatchers.is;
@@ -261,7 +261,7 @@ public class EventConfigAPIsTest {
       .getJsonArray("templates")
       .getJsonObject(0)
       .getString("outputFormat");
-    assertEquals(expected, "text/plain");
+    assertEquals("text/plain", expected);
   }
 
   @Test
@@ -281,12 +281,12 @@ public class EventConfigAPIsTest {
 
   @Test
   public void testGetAllEventEntries() {
-    requestPostEventConfig(getJsonEntity(null, RandomStringUtils.randomAlphabetic(10),
+    requestPostEventConfig(getJsonEntity(null, secure().nextAlphabetic(10),
       false, new JsonArray()))
       .then()
       .statusCode(HttpStatus.SC_CREATED);
 
-    requestPostEventConfig(getJsonEntity(null, RandomStringUtils.randomAlphabetic(20),
+    requestPostEventConfig(getJsonEntity(null, secure().nextAlphabetic(20),
       true, new JsonArray()))
       .then()
       .statusCode(HttpStatus.SC_CREATED);
@@ -318,7 +318,7 @@ public class EventConfigAPIsTest {
   @Test
   public void testPutEventConfigById() {
     String id = UUID.randomUUID().toString();
-    JsonObject entity = getJsonEntity("0002", RandomStringUtils.randomAlphabetic(20),
+    JsonObject entity = getJsonEntity("0002", secure().nextAlphabetic(20),
       true, new JsonArray());
 
     Response response = requestPutEventConfig(id, entity)

--- a/src/test/java/org/folio/impl/EventConfigAPIsTest.java
+++ b/src/test/java/org/folio/impl/EventConfigAPIsTest.java
@@ -15,9 +15,9 @@ import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.ext.web.client.HttpResponse;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.folio.HttpStatus;
 import org.folio.postgres.testing.PostgresTesterContainer;
 import org.folio.rest.RestVerticle;
 import org.folio.rest.client.TenantClient;
@@ -72,7 +72,7 @@ public class EventConfigAPIsTest {
   public Timeout timeout = Timeout.seconds(200);
 
   @BeforeClass
-  public static void setUpClass(final TestContext context) throws Exception {
+  public static void setUpClass(final TestContext context) {
     Async async = context.async();
     vertx = Vertx.vertx();
     port = NetworkUtils.nextFreePort();
@@ -112,51 +112,53 @@ public class EventConfigAPIsTest {
 
     TenantClient tenantClient = new TenantClient(String.format(OKAPI_URL, port), TENANT_ID, OKAPI_TOKEN_VAL);
     DeploymentOptions restDeploymentOptions = new DeploymentOptions().setConfig(new JsonObject().put(HTTP_PORT, port));
-    vertx.deployVerticle(RestVerticle.class.getName(), restDeploymentOptions, res -> {
-      try {
-        TenantAttributes t = new TenantAttributes().withModuleTo("mod-event-config-1.0.0");
-        tenantClient.postTenant(t, postResult -> {
-          if (postResult.failed()) {
-            Throwable cause = postResult.cause();
-            logger.error(cause);
-            context.fail(cause);
-            return;
-          }
-
-          final HttpResponse<Buffer> postResponse = postResult.result();
-          assertThat(postResponse.statusCode(), is(201));
-
-          String jobId = postResponse.bodyAsJson(TenantJob.class).getId();
-
-          tenantClient.getTenantByOperationId(jobId, 10000, getResult -> {
-            if (getResult.failed()) {
-              Throwable cause = getResult.cause();
-              logger.error(cause.getMessage());
+    vertx.deployVerticle(RestVerticle.class.getName(), restDeploymentOptions)
+      .onComplete(res -> {
+        try {
+          TenantAttributes t = new TenantAttributes().withModuleTo("mod-event-config-1.0.0");
+          tenantClient.postTenant(t, postResult -> {
+            if (postResult.failed()) {
+              Throwable cause = postResult.cause();
+              logger.error(cause);
               context.fail(cause);
               return;
             }
 
-            final HttpResponse<Buffer> getResponse = getResult.result();
-            assertThat(getResponse.statusCode(), is(200));
-            assertThat(getResponse.bodyAsJson(TenantJob.class).getComplete(), is(true));
-            async.complete();
+            final HttpResponse<Buffer> postResponse = postResult.result();
+            assertThat(postResponse.statusCode(), is(201));
+
+            String jobId = postResponse.bodyAsJson(TenantJob.class).getId();
+
+            tenantClient.getTenantByOperationId(jobId, 10000, getResult -> {
+              if (getResult.failed()) {
+                Throwable cause = getResult.cause();
+                logger.error(cause.getMessage());
+                context.fail(cause);
+                return;
+              }
+
+              final HttpResponse<Buffer> getResponse = getResult.result();
+              assertThat(getResponse.statusCode(), is(200));
+              assertThat(getResponse.bodyAsJson(TenantJob.class).getComplete(), is(true));
+              async.complete();
+            });
           });
-        });
-      } catch (Exception e) {
-        // none
-      }
-    });
+        } catch (Exception e) {
+          // none
+        }
+      });
   }
 
   @AfterClass
   public static void tearDownClass(final TestContext context) {
     Async async = context.async();
-    vertx.close(context.asyncAssertSuccess(res -> {
-      if (useExternalDatabase.equals(EXTERNAL_DATABASE_VAL)) {
-        PostgresClient.stopPostgresTester();
-      }
-      async.complete();
-    }));
+    vertx.close()
+      .onComplete(context.asyncAssertSuccess(res -> {
+        if (useExternalDatabase.equals(EXTERNAL_DATABASE_VAL)) {
+          PostgresClient.stopPostgresTester();
+        }
+        async.complete();
+      }));
   }
 
   @Before
@@ -206,7 +208,6 @@ public class EventConfigAPIsTest {
   public void testPostEventConfig() {
     String id = UUID.randomUUID().toString();
     JsonObject expectedEntity = getJsonEntity(id, "RESET_PASSWORD", false, new JsonArray());
-    String expectedDeleteMessage = "Configuration with id: '%s' was successfully deleted";
 
     // create a new event config
     Response response = requestPostEventConfig(expectedEntity)

--- a/src/test/java/org/folio/impl/util/EventConfigHelperTest.java
+++ b/src/test/java/org/folio/impl/util/EventConfigHelperTest.java
@@ -1,5 +1,8 @@
 package org.folio.impl.util;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
 import org.folio.HttpStatus;
 import org.folio.cql2pgjson.exception.CQL2PgJSONException;
 import org.folio.rest.impl.util.EventConfigHelper;
@@ -8,8 +11,6 @@ import org.junit.Test;
 
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import static org.junit.Assert.*;
-import static org.hamcrest.core.Is.*;
 
 public class EventConfigHelperTest {
 

--- a/src/test/java/org/folio/impl/util/EventConfigHelperTest.java
+++ b/src/test/java/org/folio/impl/util/EventConfigHelperTest.java
@@ -1,6 +1,6 @@
 package org.folio.impl.util;
 
-import org.apache.http.HttpStatus;
+import org.folio.HttpStatus;
 import org.folio.cql2pgjson.exception.CQL2PgJSONException;
 import org.folio.rest.impl.util.EventConfigHelper;
 import org.folio.rest.persist.cql.CQLQueryValidationException;

--- a/src/test/resources/log4j2-test.properties
+++ b/src/test/resources/log4j2-test.properties
@@ -12,7 +12,7 @@ appenders = console
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{HH:mm:ss} [$${FolioLoggingContext:requestid}] [$${FolioLoggingContext:tenantid}] [$${FolioLoggingContext:userid}] [$${FolioLoggingContext:moduleid}] %-5p %-20.20C{1} %m%n
+appender.console.layout.pattern = %d{HH:mm:ss} [$${FolioLoggingContext:requestId}] [$${FolioLoggingContext:tenantId}] [$${FolioLoggingContext:userId}] [$${FolioLoggingContext:moduleId}] %-5p %-20.20C{1} %m%n
 
 rootLogger.level = info
 rootLogger.appenderRefs = info


### PR DESCRIPTION
## Purpose
Upgrade module to Vert.x 5.0. Also update RMB dependency to the corresponding version.

## Approach
- update Vert.x version to 5.0
- update RAML dependency to 36.0.0-SNAPSHOT
- make necessary adjustments in source code and tests as per migration instructions/guides

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.

### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
[MODEVENTC-69](https://folio-org.atlassian.net/browse/MODEVENTC-69)
