### PR TITLE
[MODEVENTC-77] Validate sms template formats, bump mod-event interface to 2.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,11 @@
 ## 2.11.0 In Progress
 
+### Breaking changes
+* Constrain `sms` templates to `text/plain` ([MODEVENTC-77](https://folio-org.atlassian.net/browse/MODEVENTC-77))
+* Bump interface `mod-event` from `1.0` to `2.0`
+
 ### Tech Debt
 * Use GitHub Workflows for Maven ([MODEVENTC-74](https://folio-org.atlassian.net/browse/MODEVENTC-74))
-
----
 
 ## v2.10.0 2026-04-16
 

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -5,7 +5,7 @@
   "provides": [
     {
       "id": "mod-event",
-      "version": "1.0",
+      "version": "2.0",
       "handlers": [
         {
           "methods": [

--- a/ramls/event_config.raml
+++ b/ramls/event_config.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 title: "Event config"
 baseUri: https://github.com/folio-org/mod-event-config
-version: v1
+version: v2.0
 
 documentation:
   - title: Event config

--- a/src/main/java/org/folio/rest/impl/EventConfigAPIs.java
+++ b/src/main/java/org/folio/rest/impl/EventConfigAPIs.java
@@ -90,6 +90,11 @@ public class EventConfigAPIs implements EventConfig {
   public void postEventConfig(String lang, EventConfigEntity entity, Map<String, String> okapiHeaders,
                               Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     logger.debug("postEventConfig:: Trying to post the Event Configuration");
+    Response validationResponse = EventConfigHelper.validateSmsTemplateOutputFormats(entity);
+    if (validationResponse != null) {
+      asyncResultHandler.handle(Future.succeededFuture(validationResponse));
+      return;
+    }
     PgUtil.post(EVENT_CONFIGS, entity, okapiHeaders, vertxContext, PostEventConfigResponse.class, asyncResultHandler);
   }
 
@@ -111,6 +116,11 @@ public class EventConfigAPIs implements EventConfig {
   public void putEventConfigById(String id, String lang, EventConfigEntity entity, Map<String, String> okapiHeaders,
                                  Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     logger.debug("putEventConfigById:: Trying to update the Event Configuration By Id : {}",id);
+    Response validationResponse = EventConfigHelper.validateSmsTemplateOutputFormats(entity);
+    if (validationResponse != null) {
+      asyncResultHandler.handle(Future.succeededFuture(validationResponse));
+      return;
+    }
     PgUtil.put(EVENT_CONFIGS, entity, id, okapiHeaders, vertxContext, PutEventConfigByIdResponse.class, asyncResultHandler);
   }
 }

--- a/src/main/java/org/folio/rest/impl/util/EventConfigHelper.java
+++ b/src/main/java/org/folio/rest/impl/util/EventConfigHelper.java
@@ -1,8 +1,13 @@
 package org.folio.rest.impl.util;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.cql2pgjson.exception.CQL2PgJSONException;
+import org.folio.rest.jaxrs.model.EventConfigEntity;
+import org.folio.rest.jaxrs.model.Template;
 import org.folio.rest.persist.cql.CQLQueryValidationException;
 
 import javax.ws.rs.core.MediaType;
@@ -10,8 +15,43 @@ import javax.ws.rs.core.Response;
 
 public class EventConfigHelper {
   private static final Logger logger = LogManager.getLogger(EventConfigHelper.class);
+  private static final String SMS_DELIVERY_CHANNEL = "sms";
+  private static final String TEXT_PLAIN = "text/plain";
 
   private EventConfigHelper() {}
+
+  public static Response validateSmsTemplateOutputFormats(EventConfigEntity entity) {
+    if (entity == null || entity.getTemplates() == null) {
+      return null;
+    }
+
+    List<String> invalidTemplates = new ArrayList<>();
+    List<Template> templates = entity.getTemplates();
+    for (int index = 0; index < templates.size(); index++) {
+      Template template = templates.get(index);
+      if (
+        template != null &&
+        SMS_DELIVERY_CHANNEL.equalsIgnoreCase(template.getDeliveryChannel()) &&
+        !TEXT_PLAIN.equals(template.getOutputFormat())
+      ) {
+        invalidTemplates.add("Template %s".formatted(index));
+      }
+    }
+
+    if (invalidTemplates.isEmpty()) {
+      return null;
+    }
+
+    return Response
+      .status(Response.Status.BAD_REQUEST.getStatusCode())
+      .type(MediaType.TEXT_PLAIN)
+      .entity(
+        "SMS notification templates must use outputFormat 'text/plain'. " +
+        "Invalid template(s): " +
+        String.join(", ", invalidTemplates)
+      )
+      .build();
+  }
 
   public static Response mapException(Throwable throwable) {
     logger.debug("mapException:: Mapping Exception");
@@ -29,5 +69,4 @@ public class EventConfigHelper {
       .entity(Response.Status.INTERNAL_SERVER_ERROR.getReasonPhrase())
       .build();
   }
-
 }

--- a/src/test/java/org/folio/impl/EventConfigAPIsTest.java
+++ b/src/test/java/org/folio/impl/EventConfigAPIsTest.java
@@ -265,6 +265,38 @@ public class EventConfigAPIsTest {
   }
 
   @Test
+  public void testPostSmsEventConfigRejectsHtmlOutputFormat() {
+    JsonArray templates = createTemplates("sms", "text/html");
+    JsonObject expectedEntity = getJsonEntity(UUID.randomUUID().toString(), "sms_html", true, templates);
+
+    Response response = requestPostEventConfig(expectedEntity)
+      .then()
+      .statusCode(HttpStatus.SC_BAD_REQUEST)
+      .extract()
+      .response();
+
+    String body = response.asString();
+    assertTrue(body.contains("SMS notification templates must use outputFormat 'text/plain'"));
+    assertTrue(body.contains("Template 0"));
+  }
+
+  @Test
+  public void testPutSmsEventConfigRejectsHtmlOutputFormat() {
+    JsonArray templates = createTemplates("sms", "text/html");
+    JsonObject entity = getJsonEntity(UUID.randomUUID().toString(), "sms_html_update", true, templates);
+
+    Response response = requestPutEventConfig(UUID.randomUUID().toString(), entity)
+      .then()
+      .statusCode(HttpStatus.SC_BAD_REQUEST)
+      .extract()
+      .response();
+
+    String body = response.asString();
+    assertTrue(body.contains("SMS notification templates must use outputFormat 'text/plain'"));
+    assertTrue(body.contains("Template 0"));
+  }
+
+  @Test
   public void testGetEventEntries() {
     EventConfigCollection eventEntries = new EventConfigCollection().withTotalRecords(0);
     JsonObject expectedEntriesJson = JsonObject.mapFrom(eventEntries);

--- a/src/test/java/org/folio/impl/util/EventConfigHelperTest.java
+++ b/src/test/java/org/folio/impl/util/EventConfigHelperTest.java
@@ -2,10 +2,15 @@ package org.folio.impl.util;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertNull;
+
+import java.util.List;
 
 import org.folio.HttpStatus;
 import org.folio.cql2pgjson.exception.CQL2PgJSONException;
 import org.folio.rest.impl.util.EventConfigHelper;
+import org.folio.rest.jaxrs.model.EventConfigEntity;
+import org.folio.rest.jaxrs.model.Template;
 import org.folio.rest.persist.cql.CQLQueryValidationException;
 import org.junit.Test;
 
@@ -29,4 +34,47 @@ public class EventConfigHelperTest {
     assertThat(response.getMediaType().toString(), is(MediaType.TEXT_PLAIN));
   }
 
+  @Test
+  public void validateSmsTemplateOutputFormatsAllowsPlainTextForSmsDeliveryChannel() {
+    EventConfigEntity entity = new EventConfigEntity()
+      .withTemplates(List.of(template("sms-template", "sms", "text/plain")));
+
+    assertNull(EventConfigHelper.validateSmsTemplateOutputFormats(entity));
+  }
+
+  @Test
+  public void validateSmsTemplateOutputFormatsAllowsHtmlForEmailDeliveryChannel() {
+    EventConfigEntity entity = new EventConfigEntity()
+      .withTemplates(List.of(template("email-template", "email", "text/html")));
+
+    assertNull(EventConfigHelper.validateSmsTemplateOutputFormats(entity));
+  }
+
+  @Test
+  public void validateSmsTemplateOutputFormatsAllowsNonPlainTextForTextDeliveryChannel() {
+    EventConfigEntity entity = new EventConfigEntity()
+      .withTemplates(List.of(template("text-template", "text", "application/json")));
+
+    assertNull(EventConfigHelper.validateSmsTemplateOutputFormats(entity));
+  }
+
+  @Test
+  public void validateSmsTemplateOutputFormatsRejectsNonPlainTextForSmsDeliveryChannel() {
+    EventConfigEntity entity = new EventConfigEntity()
+      .withTemplates(List.of(template("sms-template", "sms", "text/html")));
+
+    Response response = EventConfigHelper.validateSmsTemplateOutputFormats(entity);
+
+    assertThat(response.getStatus(), is(HttpStatus.SC_BAD_REQUEST));
+    assertThat(response.getMediaType().toString(), is(MediaType.TEXT_PLAIN));
+    assertThat(response.getEntity().toString().contains("SMS notification templates must use outputFormat 'text/plain'"), is(true));
+    assertThat(response.getEntity().toString().contains("Template 0"), is(true));
+  }
+
+  private Template template(String templateId, String deliveryChannel, String outputFormat) {
+    return new Template()
+      .withTemplateId(templateId)
+      .withDeliveryChannel(deliveryChannel)
+      .withOutputFormat(outputFormat);
+  }
 }


### PR DESCRIPTION
# [Jira MODEVENTC-77](https://folio-org.atlassian.net/browse/MODEVENTC-77)

## Purpose
Constrains templates with `sms` delivery channels to `text/plain`.

## Approach
Adds new validation methods, throwing a 400 as applicable.

This is a breaking change, so the `mod-event` interface is bumped to `2.0`.

### Changes checklist
- [x] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [x] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [x] Check logging.

### TODOS and Open Questions
- [ ] Merge https://github.com/folio-org/mod-notify/pull/161 first
